### PR TITLE
qns: expand useId and Fragments answers with deeper coverage for SEO

### DIFF
--- a/questions/what-are-react-fragments-used-for/en-US.mdx
+++ b/questions/what-are-react-fragments-used-for/en-US.mdx
@@ -25,10 +25,13 @@ React Fragments allow you to group multiple elements without adding extra nodes 
 
 ### Avoiding unnecessary DOM nodes
 
-Using React Fragments helps avoid unnecessary wrapper elements in the DOM. The performance impact of one extra `<div>` is negligible in practice, so the real reasons to reach for a fragment are usually structural rather than performance-related:
+Using React Fragments helps avoid unnecessary wrapper elements in the DOM.
 
-- **Valid HTML structure**: Some elements have strict children rules. A `<table>` cannot contain a `<div>` between it and its `<tr>` rows; a `<tr>` cannot contain a `<div>` between it and its `<td>` cells. Fragments let a component return multiple `<tr>` or `<td>` siblings without breaking the table.
-- **CSS layout integrity**: When the parent uses Flexbox or CSS Grid, an extra wrapper `<div>` becomes a flex/grid item itself and disrupts the layout. Fragments keep the children as direct descendants of the layout container.
+> **Common misconception:** Fragments are often described as a performance optimization, on the assumption that one extra `<div>` per component is a meaningful cost. In practice, the cost is negligible. Browsers can render thousands of additional DOM nodes without measurable impact. The actual reasons to reach for a fragment are structural, not performance-related.
+
+- **Valid HTML structure**: Some elements have strict children rules. A `<table>` cannot contain a `<div>` between it and its `<tr>` rows; a `<tr>` cannot contain a `<div>` between it and its `<td>` cells; a `<select>` only accepts `<option>` and `<optgroup>` children. Fragments let a component return multiple `<tr>`, `<td>`, or `<option>` siblings without breaking the parent's HTML contract.
+- **CSS layout integrity**: When the parent uses Flexbox or CSS Grid, an extra wrapper `<div>` becomes a flex/grid item itself and disrupts the layout (the wrapper takes the grid slot, not its children). Fragments keep the children as direct descendants of the layout container.
+- **HOC and composition**: A higher-order component or render-prop helper that wraps `children` cannot wrap them in a `<div>` without breaking layout for every consumer. Returning the children inside a fragment lets the wrapper add behavior without adding DOM.
 - **Cleaner markup**: Avoiding pointless wrapper `<div>`s makes the rendered HTML easier to read and style.
 
 ### Syntax
@@ -57,21 +60,36 @@ There are two ways to use React Fragments:
    );
    ```
 
-### Adding keys to fragments
+### When to use `<Fragment>` instead of `<>`
 
-If you need to add a `key` to a fragment, you must use the full `React.Fragment` syntax — the shorthand `<>...</>` does not accept props of any kind. This typically comes up when rendering a list where each item needs to render multiple sibling elements.
+The shorthand `<>...</>` is concise but does not accept any props, including `key`. The single case that requires the explicit `React.Fragment` form is when a `key` is needed, which happens whenever a `map` produces items that each render more than one sibling element.
+
+The shorthand version below is incorrect because React cannot attach a key to a `<>...</>` fragment. React will emit a warning about a missing `key`:
 
 ```jsx
-return (
+// Bug: <></> cannot accept a key, so React has no way to identify these fragments
+{items.map((item) => (
   <>
-    {items.map((item) => (
-      <React.Fragment key={item.id}>
-        <ChildComponent />
-      </React.Fragment>
-    ))}
+    <dt>{item.term}</dt>
+    <dd>{item.definition}</dd>
   </>
-);
+))}
 ```
+
+The fix is to use the full `Fragment` form so you can pass a `key`:
+
+```jsx
+import { Fragment } from 'react';
+
+{items.map((item) => (
+  <Fragment key={item.id}>
+    <dt>{item.term}</dt>
+    <dd>{item.definition}</dd>
+  </Fragment>
+))}
+```
+
+`key` is the only prop `Fragment` accepts. There is no `className`, `style`, or event handler. If any of those are needed, use a real wrapper element instead.
 
 ### Use cases
 

--- a/questions/what-is-the-useid-hook-in-react-and-when-should-it-be-used/en-US.mdx
+++ b/questions/what-is-the-useid-hook-in-react-and-when-should-it-be-used/en-US.mdx
@@ -32,7 +32,31 @@ The `useId` hook was added in React 18. It returns a stable string ID tied to th
 
 The actual motivation for `useId` is server-side rendering. Before React 18, generating IDs with a module-level counter (`let next = 0; const id = next++;`) caused **hydration mismatches**: the server and the client could increment the counter in a different order, producing different IDs in the HTML versus the client tree. React would then warn (and in React 18+, throw away the hydrated subtree).
 
-`useId` sidesteps this by deriving the ID from the component's location in the React tree, which is identical on the server and the client. Producing IDs unique to one component instance is a side benefit; the main job is hydration stability.
+Module-level counters were already fragile before React 18. Any re-render, multiple `renderToString` calls sharing module state, or a tree shape that differed between server and client could desynchronize the counter. React 18's **concurrent rendering** and **streaming SSR** amplified the problem: Suspense boundaries can resolve out of order, the renderer can pause and resume work, and streamed chunks can arrive at the client in a different order than they were rendered on the server. Any ID source that depends on render order (counters, `Math.random()` seeded once, mutable module state) inherits this fragility.
+
+`useId` sidesteps it by deriving the ID from the component's location in the React tree, which is identical on the server and the client regardless of render order. Producing IDs unique to one component instance is a side benefit; the main job is hydration stability.
+
+### `useId` vs other ID-generation approaches
+
+`useId` exists specifically to be SSR-safe and stable across renders. Common alternatives fail one of those two requirements:
+
+| Approach | SSR-safe? | Stable across renders? | Use when |
+| --- | --- | --- | --- |
+| `useId()` | Yes | Yes | Component-scoped IDs that appear in rendered output. |
+| `Math.random()` | No (server and client diverge, causing hydration mismatch) | No (changes every render) | Never for render output. Only suitable for non-rendered scratch values. |
+| `crypto.randomUUID()` | No (same reason) | No | When a globally unique ID needs to be stored in your data, not generated during render. |
+| `nanoid` / `uuid` package | No (when called during render) | No (same reason) | For IDs persisted in your data model. Generate them outside render and store the result. |
+| Module-level counter | No (server and client increment in different orders) | Yes (within a session) | Was the pre-React 18 workaround. Replaced by `useId`. |
+
+If an ID appears in rendered output, it must come from `useId`. If an ID belongs to your data (a row's primary key, a user's session ID, and so on), generate it outside render and store it.
+
+### `useId` in React Server Components
+
+`useId` behaves inside Client Components the same way it does in plain client React. Two caveats apply specifically to RSC setups:
+
+- It works in synchronous Server Components but is not supported in async Server Components. If an ID is required inside an async Server Component, generate it outside render or move the rendering into a Client Component.
+- IDs are derived from the component's position in the fiber tree, including any surrounding Suspense boundaries. There is no per-Suspense namespace. The boundary is simply another node in the parent path, which is what keeps IDs in different boundaries distinct.
+- Server Actions are unrelated to ID generation. They run on the server and do not participate in render-time ID generation.
 
 ### Uniqueness scope and multiple roots
 
@@ -56,7 +80,7 @@ The same option exists on `hydrateRoot`.
 
 ### When to use `useId`
 
-The canonical use is associating labels with form controls for accessibility:
+The most common use is associating a `<label>` with its form control for accessibility:
 
 ```javascript
 import { useId } from 'react';
@@ -74,9 +98,9 @@ function NameField() {
 
 It is also useful for ARIA attributes such as `aria-describedby`, `aria-labelledby`, and `aria-controls`.
 
-### Generating multiple related IDs from one call
+### Pairing inputs with `aria-describedby` and `aria-labelledby`
 
-Do not call `useId` multiple times for related fields. Call it once and append suffixes — this keeps related IDs grouped and saves hook calls:
+A common `useId` pattern for accessibility is connecting an input to a hint, an error message, or an external label via `aria-describedby` or `aria-labelledby`. Call `useId` once per component and append suffixes for each related element. This keeps related IDs grouped, saves hook calls, and makes the relationships clear in the markup:
 
 ```javascript
 function PasswordField() {
@@ -95,11 +119,16 @@ function PasswordField() {
 }
 ```
 
+The same pattern applies to `aria-labelledby` (when the label is a separate element, not a `<label>`), `aria-controls` (a button that toggles a panel), and `aria-errormessage` (an input pointing at an error region). All of these attributes need stable IDs that survive SSR, which is what `useId` provides.
+
 ### What `useId` is not for
 
-- **Do not use it as a list `key`.** `key` needs to identify a piece of _data_ across renders; `useId` identifies a _component position_. Use a stable id from your data.
+> **Important distinction:** `useId` is not a replacement for list keys. `key` identifies a piece of _data_ across renders so React can reconcile additions, removals, and reorders. `useId` identifies a _component position_ in the tree, so it stays the same when the list is reordered, which is the wrong behavior for a key. Always use a stable ID from your data (a database id, a slug, and so on) for list keys.
+
+- **Do not use it as a list `key`.** Using `useId` as a key produces output that renders correctly at first but breaks when the list is reordered or items are inserted. See the callout above for the reason.
 - **Avoid it in CSS selectors and `document.querySelector`.** The generated format (e.g. `:r0:`) contains colons, which are valid in HTML `id` attributes but require escaping in CSS selectors. Pair `<label htmlFor>` with `<input id>` instead of selecting by id.
 - **Do not parse or rely on the format.** The exact shape (`:r0:`, `«r0»`, etc.) is an implementation detail and has changed between versions.
+- **Do not generate IDs for data with `useId`.** If the ID must outlive the component (saved to a database, sent in an API request, used as a stable record identifier), `useId` is not the right tool. Use `crypto.randomUUID()` or a UUID library and store the result.
 
 ### Practical guidance
 


### PR DESCRIPTION
- **`useId`**: added an SSR-safety comparison table covering `Math.random()`, `crypto.randomUUID()`, `nanoid`/`uuid`, and module-level counters; added a React Server Components section covering the async-Server-Component limitation and Suspense behavior; added an `aria-describedby`/`aria-labelledby` pairing section; added a callout clarifying why `useId` is not a list `key`; added an anti-pattern bullet about generating data IDs with `useId`.
- **Fragments**: added a misconception callout pushing back on the "fragments are a performance optimization" framing; added `<select>` to the strict-children examples and added an HOC/composition use case; replaced the thin "Adding keys to fragments" section with a clearer "When to use `<Fragment>` instead of `<>`" section that shows the bug shape (shorthand with multiple siblings inside `map`) alongside the fix.
